### PR TITLE
Some useful coverage config: cover branches, show missing, skip covered

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true


### PR DESCRIPTION
* Branch coverage because let's not just cover lines, let's cover the decision tree
* Show missing lines to help figure out what we've missed
* Skip showing completely covered files, because the priority is anything that might _not_ be covered