### PR TITLE
Use separate Makefile targets for each check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,22 @@ bootstrap:
 	pipenv install --dev
 
 .PHONY: check
-check:
+check: black flake8 isort mypy
+
+.PHONY: black
+black:
 	pipenv run black --check .
+
+.PHONY: flake8
+flake8:
 	pipenv run flake8 .
+
+.PHONY: isort
+isort:
 	pipenv run isort --check-only .
+
+.PHONY: mypy
+mypy:
 	pipenv run mypy .
 
 .PHONY: fix


### PR DESCRIPTION
This makes it faster to quickly iterate over e.g. fixing a type issue
without going through all the lint/isort stuff first
