### PR TITLE
Fix Dependabot ecosystem - pip, not pipenv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pipenv"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
I misread
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-dependabotyml
