### PR TITLE
Update coverage usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,6 @@ fix:
 
 .PHONY: test
 test:
-	pipenv run pytest --cov=$(SRCDIR) $(SRCDIR)
+	pipenv run coverage run --module pytest $(SRCDIR)
+	pipenv run coverage report
+	pipenv run coverage html

--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,6 @@ structlog = "*"
 black = "*"
 pytest = "*"
 coverage = "*"
-pytest-cov = "*"
 mypy = "*"
 ruff = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "889a2251b4d6144b34316c3534c2394966a00d137704d2e5ceda2508efb9d0cb"
+            "sha256": "3f96a7408a06bc8fca02e13f10222f939ed5846f2dc337be61b5e24887d159ad"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -214,11 +214,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee",
-                "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"
+                "sha256:9e5e27a08aa095dd127b9f2e764d74254f482fef22b0970773bfba79d091ab8c",
+                "sha256:eb1c8582560b34ed4ba105009a4badf7f6f85768b30126f351328507b2beb617"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.2.2"
+            "version": "==4.3.2"
         },
         "pluggy": {
             "hashes": [
@@ -237,39 +237,30 @@
             "markers": "python_version >= '3.8'",
             "version": "==8.3.2"
         },
-        "pytest-cov": {
-            "hashes": [
-                "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652",
-                "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==5.0.0"
-        },
         "ruff": {
             "hashes": [
-                "sha256:14a9528a8b70ccc7a847637c29e56fd1f9183a9db743bbc5b8e0c4ad60592a82",
-                "sha256:183b99e9edd1ef63be34a3b51fee0a9f4ab95add123dbf89a71f7b1f0c991983",
-                "sha256:34e2824a13bb8c668c71c1760a6ac7d795ccbd8d38ff4a0d8471fdb15de910b1",
-                "sha256:3b061e49b5cf3a297b4d1c27ac5587954ccb4ff601160d3d6b2f70b1622194dc",
-                "sha256:42844ff678f9b976366b262fa2d1d1a3fe76f6e145bd92c84e27d172e3c34500",
-                "sha256:47021dff5445d549be954eb275156dfd7c37222acc1e8014311badcb9b4ec8c1",
-                "sha256:500f166d03fc6d0e61c8e40a3ff853fa8a43d938f5d14c183c612df1b0d6c58a",
-                "sha256:65a533235ed55f767d1fc62193a21cbf9e3329cf26d427b800fdeacfb77d296f",
-                "sha256:70452a10eb2d66549de8e75f89ae82462159855e983ddff91bc0bce6511d0470",
-                "sha256:746af39356fee2b89aada06c7376e1aa274a23493d7016059c3a72e3b296befb",
-                "sha256:7a62d3b5b0d7f9143d94893f8ba43aa5a5c51a0ffc4a401aa97a81ed76930521",
-                "sha256:7d7bd20dc07cebd68cc8bc7b3f5ada6d637f42d947c85264f94b0d1cd9d87384",
-                "sha256:97f58fda4e309382ad30ede7f30e2791d70dd29ea17f41970119f55bdb7a45c3",
-                "sha256:bddfbb8d63c460f4b4128b6a506e7052bad4d6f3ff607ebbb41b0aa19c2770d1",
-                "sha256:ced3eeb44df75353e08ab3b6a9e113b5f3f996bea48d4f7c027bc528ba87b672",
-                "sha256:d2e2c23cef30dc3cbe9cc5d04f2899e7f5e478c40d2e0a633513ad081f7361b5",
-                "sha256:d8a136aa7d228975a6aee3dd8bea9b28e2b43e9444aa678fb62aeb1956ff2351",
-                "sha256:f92fe93bc72e262b7b3f2bba9879897e2d58a989b4714ba6a5a7273e842ad2f8"
+                "sha256:0308610470fcc82969082fc83c76c0d362f562e2f0cdab0586516f03a4e06ec6",
+                "sha256:0b52387d3289ccd227b62102c24714ed75fbba0b16ecc69a923a37e3b5e0aaaa",
+                "sha256:0ea086601b22dc5e7693a78f3fcfc460cceabfdf3bdc36dc898792aba48fbad6",
+                "sha256:34d5efad480193c046c86608dbba2bccdc1c5fd11950fb271f8086e0c763a5d1",
+                "sha256:50e30b437cebef547bd5c3edf9ce81343e5dd7c737cb36ccb4fe83573f3d392e",
+                "sha256:549daccee5227282289390b0222d0fbee0275d1db6d514550d65420053021a58",
+                "sha256:66dbfea86b663baab8fcae56c59f190caba9398df1488164e2df53e216248baa",
+                "sha256:7862f42fc1a4aca1ea3ffe8a11f67819d183a5693b228f0bb3a531f5e40336fc",
+                "sha256:803b96dea21795a6c9d5bfa9e96127cc9c31a1987802ca68f35e5c95aed3fc0d",
+                "sha256:932063a03bac394866683e15710c25b8690ccdca1cf192b9a98260332ca93408",
+                "sha256:ac3b5bfbee99973f80aa1b7cbd1c9cbce200883bdd067300c22a6cc1c7fba212",
+                "sha256:ac4b75e898ed189b3708c9ab3fc70b79a433219e1e87193b4f2b77251d058d14",
+                "sha256:bedff9e4f004dad5f7f76a9d39c4ca98af526c9b1695068198b3bda8c085ef60",
+                "sha256:c44536df7b93a587de690e124b89bd47306fddd59398a0fb12afd6133c7b3818",
+                "sha256:c4b153fc152af51855458e79e835fb6b933032921756cec9af7d0ba2aa01a258",
+                "sha256:d02a4127a86de23002e694d7ff19f905c51e338c72d8e09b56bfb60e1681724f",
+                "sha256:eebe4ff1967c838a1a9618a5a59a3b0a00406f8d7eefee97c70411fefc353617",
+                "sha256:f0f8968feea5ce3777c0d8365653d5e91c40c31a81d95824ba61d871a11b8523"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.6.3"
+            "version": "==0.6.4"
         },
         "typing-extensions": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ However, hopefully you'll appreciate some of the ideas within!
 * [Black](https://black.readthedocs.io/en/stable/) for code formatting
 * [structlog](https://www.structlog.org/en/stable/) for structured logging
 * [pytest](https://docs.pytest.org/en/stable/) for testing
-* [Coverage.py](https://coverage.readthedocs.io/en/latest/) and [pytest-cov](https://github.com/pytest-dev/pytest-cov) for measuring code coverage
+* [Coverage.py](https://coverage.readthedocs.io/en/latest/) for measuring code coverage
 * [Mypy](https://www.mypy-lang.org/) for type checking
 * [Ruff](https://docs.astral.sh/ruff/) for [linting ALL the things](https://docs.astral.sh/ruff/rules/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,14 @@
 [tool.coverage.run]
 branch = true
+dynamic_context = "test_function"
 
 [tool.coverage.report]
 fail_under = 100
 show_missing = true
 skip_covered = true
+
+[tool.coverage.html]
+show_contexts = true
 
 [tool.ruff]
 select = [


### PR DESCRIPTION
This addresses two points to save on bookkeeping.

The smaller feature is a nice little UX improvement from coverage that shows you which tests exercised a given line in a reported module.

The bigger one is removing pytest-cov.  Pytest-cov effectively has to reimplement an entire UI around coverage to be a pytest plugin, despite coverage running pytest being absoutely fine.  I haven't looked in a while but previously the author of coverage hasn't been a fan of the extra work needed to support pytest-cov or that it's possible for coverage to break pytest-cov who have relied on internal APIs in the past.  The main difference is the `test` target has grown some extra lines to build the report and HTML outputs. 