### PR TITLE
Get Dependabot to update the uv dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/

I, uh, missed that the "pip" ecosystem wouldn't cover it...!

Though it only launched on the 13th, this commit was authored on the
16th, and https://github.com/dependabot/dependabot-core/issues/10478
suggests some initial teething problems, so it might be worth a wait
