### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   UV_LOCKED: 1  # Ensure lockfile is up to date at test time
 


### PR DESCRIPTION
Potential fix for [https://github.com/doismellburning/python-template/security/code-scanning/4](https://github.com/doismellburning/python-template/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token access unless overridden later. For this workflow, the minimal safe baseline is:

- `contents: read` (needed for checkout and repository read access)

Edit `.github/workflows/test.yml` by inserting `permissions:` after the `concurrency` block (or near the top-level keys before `jobs:`). No imports, methods, or additional definitions are needed (YAML workflow only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
